### PR TITLE
Change uint32_t and int32_t types to long

### DIFF
--- a/include/ttl/cstdint
+++ b/include/ttl/cstdint
@@ -23,5 +23,5 @@ typedef unsigned char  uint8_t;
 typedef signed char    int8_t;
 typedef unsigned short uint16_t;
 typedef signed short   int16_t;
-typedef unsigned int   uint32_t;
-typedef signed int     int32_t;
+typedef unsigned long  uint32_t;
+typedef signed long    int32_t;


### PR DESCRIPTION
Update the definitions of `uint32_t` and `int32_t` to use `long` instead of `int` for better compatibility.  #29 