### PR TITLE
Add hello world starter and slim bootstrap copies

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ own executable and launched from the menu with `LoadProgram()`.
 
 | App | Source | Description |
 |-----|--------|-------------|
+| Hello, World! | [src/helloworld](src/helloworld) | Minimal C example that logs and draws centered text. |
 | Cel rotation | [src/cel_rotation](src/cel_rotation) | C++ cel rotation and zoom demo. |
 | 3D 3DO logo | [src/3d_3do_logo](src/3d_3do_logo) | 3D logo rendering demo. |
 | Rotating cube | [src/rotating_cube](src/rotating_cube) | Simple rotating 3D cube demo. |

--- a/bin/buildtools/linux/bootstrap-3do-project
+++ b/bin/buildtools/linux/bootstrap-3do-project
@@ -38,16 +38,21 @@ cp "${SRC_PATH}/activate-env" "${DST_PATH}/activate-env"
 echo "Copying Makefile"
 cp "${SRC_PATH}/Makefile" "${DST_PATH}/Makefile"
 
-echo "Copying takeme (CDROM filesystem contents)"
-cp -r "${SRC_PATH}/takeme" "${DST_PATH}/takeme"
+echo "Copying takeme (core CDROM filesystem contents)"
+mkdir -p "${DST_PATH}/takeme"
+cp "${SRC_PATH}/takeme/AppStartup" "${DST_PATH}/takeme/AppStartup"
+cp "${SRC_PATH}/takeme/BannerScreen" "${DST_PATH}/takeme/BannerScreen"
+cp -r "${SRC_PATH}/takeme/System" "${DST_PATH}/takeme/System"
 
 [ -e "${DST_PATH}/data" ] && \
     echo "Copying data/* into takeme/" && \
     cp -r "${DST_PATH}/data/"* "${DST_PATH}/takeme/"
 
-[ ! -d "${DST_PATH}/src" ] && \
-    echo "Copying src" && \
-    cp -vr "${SRC_PATH}/src" "${DST_PATH}/src"
+if [ ! -d "${DST_PATH}/src" ]; then
+    echo "Copying starter src/main.c"
+    mkdir -p "${DST_PATH}/src"
+    cp "${SRC_PATH}/src/helloworld/main.c" "${DST_PATH}/src/main.c"
+fi
 
 printf '%s' "${SRC_PATH}" > "${DST_PATH}/.devkit-path"
 

--- a/bin/buildtools/win/bootstrap-3do-project
+++ b/bin/buildtools/win/bootstrap-3do-project
@@ -38,16 +38,21 @@ cp "${SRC_PATH}/activate-env" "${DST_PATH}/activate-env"
 echo "Copying Makefile"
 cp "${SRC_PATH}/Makefile" "${DST_PATH}/Makefile"
 
-echo "Copying takeme (CDROM filesystem contents)"
-cp -r "${SRC_PATH}/takeme" "${DST_PATH}/takeme"
+echo "Copying takeme (core CDROM filesystem contents)"
+mkdir -p "${DST_PATH}/takeme"
+cp "${SRC_PATH}/takeme/AppStartup" "${DST_PATH}/takeme/AppStartup"
+cp "${SRC_PATH}/takeme/BannerScreen" "${DST_PATH}/takeme/BannerScreen"
+cp -r "${SRC_PATH}/takeme/System" "${DST_PATH}/takeme/System"
 
 [ -e "${DST_PATH}/data" ] && \
     echo "Copying data/* into takeme/" && \
     cp -r "${DST_PATH}/data/"* "${DST_PATH}/takeme/"
 
-[ ! -d "${DST_PATH}/src" ] && \
-    echo "Copying src" && \
-    cp -vr "${SRC_PATH}/src" "${DST_PATH}/src"
+if [ ! -d "${DST_PATH}/src" ]; then
+    echo "Copying starter src/main.c"
+    mkdir -p "${DST_PATH}/src"
+    cp "${SRC_PATH}/src/helloworld/main.c" "${DST_PATH}/src/main.c"
+fi
 
 printf '%s' "${SRC_PATH}" > "${DST_PATH}/.devkit-path"
 

--- a/bin/buildtools/win/bootstrap-3do-project.bat
+++ b/bin/buildtools/win/bootstrap-3do-project.bat
@@ -20,15 +20,19 @@ if exist "%DST_PATH%\takeme\" (
     exit /b 1
 )
 
-echo "Copying takeme (CDROM filesystem contents)"
-xcopy "%SRC_PATH%\takeme" "%DST_PATH%\takeme" /Q /E /I /C /-Y
+echo "Copying takeme (core CDROM filesystem contents)"
+mkdir "%DST_PATH%\takeme"
+copy /Y "%SRC_PATH%\takeme\AppStartup" "%DST_PATH%\takeme\AppStartup"
+copy /Y "%SRC_PATH%\takeme\BannerScreen" "%DST_PATH%\takeme\BannerScreen"
+xcopy "%SRC_PATH%\takeme\System" "%DST_PATH%\takeme\System" /Q /E /I /C /-Y
 IF EXIST "%DST_PATH%\data" (
    echo "Copying data/* into takeme/"
    xcopy "%DST_PATH%\data\*" "%DST_PATH%\takeme" /Q /E /I /C /-Y
 )
 IF NOT EXIST "%DST_PATH%\src" (
-   echo "Copying src"
-   xcopy "%SRC_PATH%\src" "%DST_PATH%\src" /Q /E /I /C /-Y
+   echo "Copying starter src/main.c"
+   mkdir "%DST_PATH%\src"
+   copy /Y "%SRC_PATH%\src\helloworld\main.c" "%DST_PATH%\src\main.c"
 )
 
 echo "Copying build files"

--- a/src/helloworld/main.c
+++ b/src/helloworld/main.c
@@ -1,0 +1,137 @@
+/*
+  ISC License
+
+  Copyright (c) 2026, Antonio SJ Musumeci <trapexit@spawn.link>
+
+  Permission to use, copy, modify, and/or distribute this software for any
+  purpose with or without fee is hereby granted, provided that the above
+  copyright notice and this permission notice appear in all copies.
+
+  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+
+#include "controlpad.h"
+#include "debug.h"
+#include "displayutils.h"
+#include "event.h"
+#include "graphics.h"
+#include "operror.h"
+#include "stdio.h"
+#include "types.h"
+
+#define SCREEN_WIDTH 320
+#define SCREEN_HEIGHT 240
+#define TEXT_HEIGHT 8
+#define GLYPH_WIDTH 8
+#define HELLO_TEXT "Hello, World!"
+#define HELLO_TEXT_LEN (sizeof(HELLO_TEXT) - 1)
+#define EXIT_TEXT "Press X to return"
+#define EXIT_TEXT_LEN (sizeof(EXIT_TEXT) - 1)
+
+static
+void
+ClearScreen(ScreenContext *sc_)
+{
+  Rect rect;
+  GrafCon gc;
+
+  rect.rect_XLeft = 0;
+  rect.rect_YTop = 0;
+  rect.rect_XRight = SCREEN_WIDTH;
+  rect.rect_YBottom = SCREEN_HEIGHT;
+
+  SetFGPen(&gc, MakeRGB15(0,0,0));
+
+  FillRect(sc_->sc_BitmapItems[sc_->sc_curScreen],&gc,&rect);
+}
+
+static
+void
+DrawText(ScreenContext *sc_,
+         const i32      x_,
+         const i32      y_,
+         const char    *text_,
+         Color          color_)
+{
+  GrafCon gc;
+
+  SetFGPen(&gc,color_);
+  MoveTo(&gc,x_,y_);
+  DrawText8(&gc,sc_->sc_BitmapItems[sc_->sc_curScreen],(const uint8*)text_);
+}
+
+static
+void
+WaitForExit(void)
+{
+  Err err;
+  u32 buttons;
+
+  do
+    {
+      buttons = 0;
+      err = DoControlPad(1, &buttons, 0);
+      if(err < 0)
+        {
+          printf("DoControlPad failed: ");
+          PrintfSysErr(err);
+          return;
+        }
+    }
+  while((buttons & ControlX) == 0);
+}
+
+int
+main(int    argc_,
+     char **argv_)
+{
+  ScreenContext sc;
+  Err err;
+  int32 helloX;
+  int32 helloY;
+  int32 exitX;
+
+  (void)argc_;
+  (void)argv_;
+
+  kprintf(HELLO_TEXT "\n");
+
+  err = InitControlPad(1);
+  if(err < 0)
+    {
+      printf("InitControlPad failed: ");
+      PrintfSysErr(err);
+      return (int)err;
+    }
+
+  err = CreateBasicDisplay(&sc, DI_TYPE_DEFAULT, 2);
+  if(err < 0)
+    {
+      printf("CreateBasicDisplay failed: ");
+      PrintfSysErr(err);
+      KillControlPad();
+      return (int)err;
+    }
+
+  sc.sc_curScreen = 0;
+  helloX = ((SCREEN_WIDTH - (HELLO_TEXT_LEN * GLYPH_WIDTH)) / 2);
+  helloY = ((SCREEN_HEIGHT - TEXT_HEIGHT) / 2);
+  exitX  = ((SCREEN_WIDTH - (EXIT_TEXT_LEN * GLYPH_WIDTH)) / 2);
+
+  ClearScreen(&sc);
+  DrawText(&sc, helloX, helloY, HELLO_TEXT, MakeRGB15(31, 31, 31));
+  DrawText(&sc, exitX, helloY + 20, EXIT_TEXT, MakeRGB15(18, 18, 18));
+  DisplayScreen(sc.sc_Screens[sc.sc_curScreen], 0);
+
+  WaitForExit();
+
+  DeleteBasicDisplay(&sc);
+  KillControlPad();
+  return 0;
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -50,6 +50,7 @@ run_example(const Example &example)
 
 static const Example examples[] =
   {
+    { "Hello, World!",     "$boot/helloworld" },
     { "Cel rotation",      "$boot/cel_rotation" },
     { "3D 3DO logo",       "$boot/3d_3do_logo" },
     { "Rotating cube",     "$boot/rotating_cube" },


### PR DESCRIPTION
- Add a Hello World example and include it in the README and launcher menu.
- Update bootstrap scripts to seed only core takeme files and the starter source.