### PR TITLE
Add signed int typedefs and nofp/no stack-check flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,19 +56,47 @@ endif
 #             The default Procedure Call Standard (PCS) for the ARM compiler, and
 #             the assembler in SDT 2.50 and C++ 1.10 is now:
 #             -apcs 3/32/nofp/noswst/narrow/softfp
+# nofp      : Part of the -apcs string. In the default fp variant, register r11 is
+#             reserved as the frame pointer: every function with a non-trivial frame
+#             saves it in the prologue, points it at the current stack pointer, and
+#             addresses its locals and parameters through it, which also lets a
+#             debugger walk the frame chain to produce backtraces.
+#             With nofp, r11 is freed for general use as an ordinary callee-saved
+#             variable register (v6). The prologue/epilogue no longer save and
+#             restore the frame pointer, locals are addressed relative to sp instead
+#             of r11, and the compiler gains a full extra register to relieve
+#             register pressure. Net effect: smaller, faster code.
+#             It is ABI compatible: arguments and return values are passed identically
+#             in both variants, and r11 is callee-saved either way, so objects
+#             compiled with and without a frame pointer link and interoperate freely.
+#             The only thing lost is debugger stack backtraces, which is irrelevant
+#             here because the original remote debugger is not used.
+# -zpno_check_stack : -zp passes options to the compiler's pragma system, so this is
+#             equivalent to #pragma no_check_stack. By default the compiler emits a
+#             stack-limit check in every function prologue that allocates stack space:
+#             the new sp is compared against the stack limit maintained by the runtime
+#             and a call to __rt_stkovf_split or __rt_stkovf_split_small is made when
+#             the frame could overflow, ultimately invoking __rt_stkovf_handler to
+#             abort cleanly.
+#             no_check_stack removes that compare-plus-call from every prologue,
+#             saving cycles (a call costs a pipeline refill on the ARM60). The
+#             tradeoff: stack exhaustion is no longer detected. The stack silently
+#             grows into adjacent memory and corrupts it (or raises a data abort on
+#             an unmapped page) instead of aborting with a clear error. Acceptable
+#             because 3DO task stacks and frame usage are bounded and known.
 ifeq ($(DEBUG),1)
 OPT      = -O0
 DEFFLAGS = -DDEBUG=1
 else
-OPT      = -O2
+OPT      = -O2 -zpno_check_stack
 DEFFLAGS = -DNDEBUG=1
 endif
 
 INCPATH  = ${TDO_DEVKIT_PATH}/include
 INCFLAGS = -I$(INCPATH)/3do -I$(INCPATH)/community -I$(INCPATH)/ttl
-CFLAGS   = $(OPT) -bigend -za1 -zi4 -fa -fh -fx -fpu none -arch 3 -apcs "3/32/fp/swst/wide/softfp"
+CFLAGS   = $(OPT) -bigend -za1 -zi4 -fa -fh -fx -fpu none -arch 3 -apcs "3/32/nofp/swst/wide/softfp"
 CXXFLAGS = $(CFLAGS)
-ASFLAGS  = -bigend -fpu none -arch 3 -apcs "3/32/fp/swst"
+ASFLAGS  = -bigend -fpu none -arch 3 -apcs "3/32/nofp/swst"
 ARMLIB   = armlib
 ARMLIBFLAGS = -c -o
 LIBPATH  = ${TDO_DEVKIT_PATH}/lib

--- a/include/3do/types_ints.h
+++ b/include/3do/types_ints.h
@@ -2,6 +2,7 @@
 
 /* 8bit */
 typedef signed char    i8;
+typedef i8             s8;
 typedef unsigned char  u8;
 typedef i8             int8;
 typedef i8             sint8;
@@ -11,6 +12,7 @@ typedef u8             uint8;
 typedef u8             uchar;
 typedef u8             ubyte;
 typedef volatile i8    vi8;
+typedef volatile s8    vs8;
 typedef volatile u8    vu8;
 typedef volatile int8  vint8;
 typedef volatile sint8 vsint8;
@@ -19,12 +21,14 @@ typedef volatile uint8 vuint8;
 /* 16bit */
 /* generally avoid 16bit ints */
 typedef signed short    i16;
+typedef i16             s16;
 typedef unsigned short  u16;
 typedef i16             int16;
 typedef i16             sint16;
 typedef u16             uint16;
 typedef u16             unichar;
 typedef volatile i16    vi16;
+typedef volatile s16    vs16;
 typedef volatile u16    vu16;
 typedef volatile int16  vint16;
 typedef volatile sint16 vsint16;
@@ -32,12 +36,14 @@ typedef volatile uint16 vuint16;
 
 /* 32bit */
 typedef signed long     i32;
+typedef i32             s32;
 typedef unsigned long   u32;
 typedef i32             int32;
 typedef i32             sint32;
 typedef u32             uint32;
 typedef u32             ulong;
 typedef volatile i32    vi32;
+typedef volatile s32    vs32;
 typedef volatile u32    vu32;
 typedef volatile int32  vint32;
 typedef volatile sint32 vsint32;


### PR DESCRIPTION
- Add s8/s16/s32 signed typedefs and vs8/vs16/vs32 volatile variants to types_ints.h
- Compile with -apcs nofp: free r11 as a variable register and drop frame pointer prologue/epilogue overhead
- Add -zpno_check_stack to release OPT to remove per-function stack-limit checks
- Document both flags with technical explanations in the Makefile flag reference